### PR TITLE
#10 指摘事項修正

### DIFF
--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -41,12 +41,6 @@
             </div>
 
             <div class="flex items-center justify-end mt-4">
-                @if (Route::has('password.request'))
-                    <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('password.request') }}">
-                        {{ __('Forgot your password?') }}
-                    </a>
-                @endif
-
                 <x-button class="ml-3">
                     {{ __('Log in') }}
                 </x-button>

--- a/src/routes/auth.php
+++ b/src/routes/auth.php
@@ -21,12 +21,6 @@ Route::middleware('guest')->group(function () {
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
-    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
-
-    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
-
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
                 ->name('password.reset');
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TaskController;
 
 /*
 |--------------------------------------------------------------------------
@@ -13,11 +14,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', 'App\Http\Controllers\TaskController@index');
-Route::resource('tasks', 'App\Http\Controllers\TaskController');
-
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth'])->name('dashboard');
+Route::get('/', [TaskController::class, 'index']);
+Route::resource('tasks', TaskController::class);
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
> 1. ルーティングでコントローラークラスのNameSpaceをフルパスで記述しているが、長くなるので不要。laravel9からは、use 宣言だけして、クラス名のみ書けばいい。
> [公式Document](https://readouble.com/laravel/9.x/ja/routing.html)
- `TaskController`をuse宣言し、クラス名のみ記載するように変更。（`src/routes/web.php`）


> 2. 自動生成されたであろう、route/auth.php ですが、おそらく不要な機能のRouteは削除できておらず、定義されたままです。
> 導線がない場合は、Route最悪残っててもユーザーにはあまり気付かれないですが、今回はForgetPasswordの導線があるので、せめて導線を削除しましょう。理想は必要なRoute定義のみ残すことです。
- `password.request`の動線を削除。（`src/resources/views/auth/login.blade.php`）
- `password.request`のルーティングを削除。（`src/routes/auth.php`）
- `dashboard`ページも不要なページのためルーティングを削除。（`src/routes/web.php`）
    アカウント作成後、dashboardページへ飛ばされるため"404"が表示されてしまうが、#11 で修正します。